### PR TITLE
Add HTTPS and config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,55 @@
     filter      Check filter for entities
     help        Help about any command
     log         Get logs
+    rewrite     Control DNS rewrites
     service     Alter filtered services
     status      Check and change adblocking status
 
     Flags:
     -d, --debug     Enable debug mode
     -h, --help      help for adctl
-    -v, --version   version for adctl
 
     Use "adctl [command] --help" for more information about a command.
 
-You need three environment variables: 
+## Configuration
+
+You can configure `adctl` using either environment variables or configuration files.
+
+### Environment Variables
 
     ADCTL_USERNAME="<username you use to log into the AdGuard Home web UI>"
     ADCTL_PASSWORD="<password>"
-    ADCTL_HOST="<host:port, e.g., router.example.com:8080>
+    ADCTL_HOST="<host:port, e.g., router.example.com:8080, or https://router.example.com>"
 
-The username and password are what you'd use to log into the AdGuard Home console. `ADCTL_HOST` is the host and port you use to reach the GUI.  Mine is set to `router:8080` but IP address will work too. AdGuard Home doesn't support auth tokens so hardcoded password is all you get. Also, the connection to the server is HTTP, not HTTPS, so your password is sent in cleartext. Use a unique password! 
+### Configuration Files
 
-I might add Viper support so `adctl` can get its config from a file, but right now env vars is all there is.
+`adctl` also supports loading configuration from files:
+
+1. **Global configuration**: `/etc/adctl.conf`
+2. **User configuration**: `~/.adctl` (in your home directory)
+
+Configuration files use a simple `KEY=VALUE` format:
+
+```bash
+# AdGuard Control configuration
+ADCTL_HOST=adguard.local:3000
+ADCTL_USERNAME=admin
+ADCTL_PASSWORD=your_password_here
+```
+
+**Priority order** (later sources override earlier ones):
+1. Global config file (`/etc/adctl.conf`)
+2. User config file (`~/.adctl`)
+3. Environment variables
+
+
+### Authentication Notes
+
+The username and password are what you'd use to log into the AdGuard Home console. `ADCTL_HOST` is the host and port you use to reach the GUI.  Mine is set to `router:8080` but IP address will work too. AdGuard Home doesn't support auth tokens so hardcoded password is all you get.
+
+The default connection is HTTP, so if used without TLS, your password is sent in cleartext.
+
+To securely connect with TLS, prefix your `ADCTL_HOST` variable with `https://`.
 
 All output is json and suitable for piping to `jq` and `gron` and such. 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/ewosborne/adctl/common"
 	"github.com/spf13/cobra"
 )
 
@@ -53,6 +54,11 @@ func init() {
 			debugLogger.SetOutput(os.Stderr)
 		} else {
 			debugLogger.SetOutput(io.Discard)
+		}
+
+		// Load configuration from files
+		if err := common.LoadConfig(); err != nil {
+			debugLogger.Printf("Warning: %v", err)
 		}
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -18,14 +18,20 @@ type CommandArgs struct {
 }
 
 func GetBaseURL() (url.URL, error) {
-	var ret = url.URL{Scheme: "http"}
-
 	h, err := getHost()
 	if err != nil {
-		return ret, err
+		return url.URL{}, err
 	}
 
-	ret.Host = fmt.Sprint(h)
+	scheme := "http"
+	if len(h) >= 8 && h[:8] == "https://" {
+		scheme = "https"
+		h = h[8:]
+	} else if len(h) >= 7 && h[:7] == "http://" {
+		scheme = "http"
+		h = h[7:]
+	}
+	ret := url.URL{Scheme: scheme, Host: fmt.Sprint(h)}
 	return ret, nil
 
 }

--- a/common/common.go
+++ b/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -15,6 +18,75 @@ type CommandArgs struct {
 	RequestBody map[string]any
 	Method      string
 	URL         url.URL
+}
+
+// LoadConfig reads configuration files and sets environment variables if they're not already set
+func LoadConfig() error {
+	configs := map[string]string{}
+
+	if err := readConfigFile("/etc/adctl.conf", configs); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("error reading /etc/adctl.conf: %w", err)
+		}
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("error getting user home directory: %w", err)
+	}
+	userConfigPath := filepath.Join(homeDir, ".adctl")
+	if err := readConfigFile(userConfigPath, configs); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("error reading %s: %w", userConfigPath, err)
+		}
+	}
+
+	envVarsSet := 0
+	for key, value := range configs {
+		if _, exists := os.LookupEnv(key); !exists {
+			os.Setenv(key, value)
+			envVarsSet++
+		}
+	}
+
+	return nil
+}
+
+// readConfigFile reads a configuration file and parses key=value pairs
+func readConfigFile(filename string, configs map[string]string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') ||
+			(value[0] == '\'' && value[len(value)-1] == '\'')) {
+			value = value[1 : len(value)-1]
+		}
+
+		if key == "ADCTL_HOST" || key == "ADCTL_USERNAME" || key == "ADCTL_PASSWORD" {
+			configs[key] = value
+		}
+	}
+
+	return scanner.Err()
 }
 
 func GetBaseURL() (url.URL, error) {


### PR DESCRIPTION
This PR adds support for connections over HTTPS and support for config files.

To connect over HTTPS, simply prefix your ADCTL_HOST variable with `https://`, port 443 is automatically assumed, so be sure to add the port number if it differs.
HTTP is still the default to no break existing users.

A config file can now be defined with priority ordering (later sources override earlier ones):
1. Global config file (`/etc/adctl.conf`)
2. User config file (`~/.adctl`)
3. Environment variables